### PR TITLE
Basic Navigation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5665,6 +5665,25 @@
       "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.3.0.tgz",
       "integrity": "sha512-GTCJtzJmkFLWRfFJuoo9RWWa/FfamUHgiFosxi/X1Ani4AVWbeyBenZTNX6dM+7WSbbFfTo/25eh0LLkwHMw2w=="
     },
+    "graphql-syntax-highlighter-react": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/graphql-syntax-highlighter-react/-/graphql-syntax-highlighter-react-0.4.0.tgz",
+      "integrity": "sha512-nwEWKY4RE9Zmq+LNiZ1AP4QPOZx1CI0YUexbx1tZ70lad0KdGbFF8Xc7VvRbJEYt+i2U03GjFdJEA/f63xS1XQ==",
+      "requires": {
+        "graphql": "14.0.2",
+        "prop-types": "^15.6.0"
+      },
+      "dependencies": {
+        "graphql": {
+          "version": "14.0.2",
+          "resolved": "https://registry.npmjs.org/graphql/-/graphql-14.0.2.tgz",
+          "integrity": "sha512-gUC4YYsaiSJT1h40krG3J+USGlwhzNTXSb4IOZljn9ag5Tj+RkoXrWp+Kh7WyE3t1NCfab5kzCuxBIvOMERMXw==",
+          "requires": {
+            "iterall": "^1.2.2"
+          }
+        }
+      }
+    },
     "handle-thing": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-2.0.1.tgz",
@@ -6598,6 +6617,11 @@
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
       "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
       "dev": true
+    },
+    "iterall": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/iterall/-/iterall-1.3.0.tgz",
+      "integrity": "sha512-QZ9qOMdF+QLHxy1QIpUHUU1D5pS2CG2P69LF6L6CPjPYA/XMOmKV3PZpawHoAjHNyB0swdVTRxdYT4tbBbxqwg=="
     },
     "jest-worker": {
       "version": "26.2.1",

--- a/package.json
+++ b/package.json
@@ -63,6 +63,8 @@
   },
   "dependencies": {
     "graphql": "^15.3.0",
+    "graphql-syntax-highlighter-react": "^0.4.0",
+    "prop-types": "^15.7.2",
     "react": "^16.13.1",
     "react-dom": "^16.13.1"
   }

--- a/src/components/DiffInfo.jsx
+++ b/src/components/DiffInfo.jsx
@@ -1,9 +1,12 @@
 import * as React from 'react';
+import PropTypes from 'prop-types';
 
 // export interface DiffInfoProps {}
 
-const DiffInfo = () => {
-  return <div>DiffInfo here</div>;
+const DiffInfo = ({ diff }) => {
+  return <div>{diff}</div>;
 };
+
+DiffInfo.propTypes = { diff: PropTypes.string.isRequired };
 
 export default DiffInfo;

--- a/src/components/HistoryView.jsx
+++ b/src/components/HistoryView.jsx
@@ -1,20 +1,27 @@
 import * as React from 'react';
+import { dummyList } from '../dummyData/data';
+import HistoryViewQuery from './HistoryViewQuery';
 
 // export interface HistoryViewProps {}
 
 const HistoryView = () => {
+  // Use Reudx hook to get list of queries
+  const queryHistory = dummyList;
+  // This should probably be a redux hook to set the active query in App state?
+  const [activeQuery, setActiveQuery] = React.useState(-1);
+  const queries = [];
+  for (let i = 0; i < queryHistory.length; i += 1) {
+    queries.push(<HistoryViewQuery key={i} queryNum={i + 1} onClick={() => setActiveQuery(i)} />);
+  }
+
   return (
     <div className="history-view">
       <h1>Queries</h1>
-      <div className="query-card">
-        <p>Query 1</p>
-      </div>
-      <div className="query-card">
-        <p>Query 2</p>
-      </div>
-      <div className="query-card">
-        <p>Query 3</p>
-      </div>
+      <h2>
+        ActiveQuery:
+        {activeQuery}
+      </h2>
+      {queries}
     </div>
   );
 };

--- a/src/components/HistoryViewQuery.jsx
+++ b/src/components/HistoryViewQuery.jsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const HistoryViewQuery = ({ queryNum, onClick }) => {
+  return (
+    <div className="query-card" onClick={onClick}>
+      <p>{`Query ${queryNum}`}</p>
+    </div>
+  );
+};
+
+HistoryViewQuery.propTypes = {
+  queryNum: PropTypes.number.isRequired,
+  onClick: PropTypes.func.isRequired,
+};
+
+export default HistoryViewQuery;

--- a/src/components/Nav.jsx
+++ b/src/components/Nav.jsx
@@ -1,24 +1,27 @@
 import * as React from 'react';
+import PropTypes from 'prop-types';
 
 // export interface NavProps {}
 
-const Nav = () => {
+const Nav = ({ setSelectedInfo }) => {
   return (
     <div className="nav">
-      <div className="nav-button">
+      <div className="nav-button" onClick={() => setSelectedInfo('QueryInfo')}>
         <p>Query</p>
       </div>
-      <div className="nav-button">
+      <div className="nav-button" onClick={() => setSelectedInfo('ResponseInfo')}>
+        <p>Response</p>
+      </div>
+      <div className="nav-button" onClick={() => setSelectedInfo('StateInfo')}>
         <p>Cache</p>
       </div>
-      <div className="nav-button">
+      <div className="nav-button" onClick={() => setSelectedInfo('DiffInfo')}>
         <p>Diff</p>
-      </div>
-      <div className="nav-button">
-        <p>History</p>
       </div>
     </div>
   );
 };
+
+Nav.propTypes = { setSelectedInfo: PropTypes.func.isRequired };
 
 export default Nav;

--- a/src/components/QueryInfo.jsx
+++ b/src/components/QueryInfo.jsx
@@ -1,9 +1,13 @@
 import * as React from 'react';
+import PropTypes from 'prop-types';
+import { GraphqlCodeBlock } from 'graphql-syntax-highlighter-react';
 
 // export interface QueryInfoProps {}
 
-const QueryInfo = () => {
-  return <div>QueryInfo here</div>;
+const QueryInfo = ({ queryString }) => {
+  return <GraphqlCodeBlock className="GraphqlCodeBlock" queryBody={queryString} />;
 };
+
+QueryInfo.propTypes = { queryString: PropTypes.string.isRequired };
 
 export default QueryInfo;

--- a/src/components/ResponseInfo.jsx
+++ b/src/components/ResponseInfo.jsx
@@ -1,9 +1,12 @@
 import * as React from 'react';
+import PropTypes from 'prop-types';
 
 // export interface ResponseInfoProps {}
 
-const ResponseInfo = () => {
-  return <div>ResponseInfo here</div>;
+const ResponseInfo = ({ responseString }) => {
+  return <div>{responseString}</div>;
 };
+
+ResponseInfo.propTypes = { responseString: PropTypes.string.isRequired };
 
 export default ResponseInfo;

--- a/src/components/StateInfo.jsx
+++ b/src/components/StateInfo.jsx
@@ -1,9 +1,12 @@
 import * as React from 'react';
+import PropTypes from 'prop-types';
 
 // export interface StateInfoProps {}
 
-const StateInfo = () => {
-  return <div>StateInfo here</div>;
+const StateInfo = ({ stateSnapshot }) => {
+  return <div>{stateSnapshot}</div>;
 };
+
+StateInfo.propTypes = { stateSnapshot: PropTypes.string.isRequired };
 
 export default StateInfo;

--- a/src/containers/InfoContainer.jsx
+++ b/src/containers/InfoContainer.jsx
@@ -4,6 +4,7 @@ import QueryInfo from '../components/QueryInfo';
 import ResponseInfo from '../components/ResponseInfo';
 import StateInfo from '../components/StateInfo';
 import DiffInfo from '../components/DiffInfo';
+import { dummyQuery } from '../dummyData/data';
 
 // export interface InfoContainerProps {}
 
@@ -12,16 +13,19 @@ import DiffInfo from '../components/DiffInfo';
 // };
 
 const InfoContainer = () => {
-  const [selectedInfo, setSelectedInfo] = React.useState('');
+  // changes the info based on the tab selected
+  const [selectedInfo, setSelectedInfo] = React.useState('QueryInfo');
+  // get selected query based on state
+  const selectedQuery = dummyQuery;
   const info = {
-    QueryInfo: <QueryInfo />,
-    ResponseInfo: <ResponseInfo />,
-    StateInfo: <StateInfo />,
-    DiffInfo: <DiffInfo />,
+    QueryInfo: <QueryInfo queryString={selectedQuery.queryString} />,
+    ResponseInfo: <ResponseInfo responseString={selectedQuery.responseString} />,
+    StateInfo: <StateInfo stateSnapshot={selectedQuery.stateSnapshot} />,
+    DiffInfo: <DiffInfo diff={selectedQuery.diff} />,
   };
   return (
     <>
-      <Nav />
+      <Nav setSelectedInfo={setSelectedInfo} />
       {/* Use info object to conditionally render out QueryInfo | ResponseInfo | StateInfo | DiffInfo */}
       {info[selectedInfo]}
     </>

--- a/src/dummyData/data.js
+++ b/src/dummyData/data.js
@@ -1,0 +1,485 @@
+export const dummyList = [
+  {
+    queryString: `
+      query IsUserLoggedIn {
+        isLoggedIn @client
+      }
+    `,
+    responseString: `
+      {
+        "data": {},
+        "loading": false,
+        "networkStatus": 7,
+        "stale": false
+      }
+    `,
+    stateSnapshot: `TBD`,
+    diff: `TBD`,
+  },
+  {
+    queryString: `
+      query GetLaunchList($after: String) {
+        launches(after: $after) {
+          cursor
+          hasMore
+          launches {
+            ...LaunchTile
+            __typename
+          }
+          __typename
+        }
+      }
+      
+      fragment LaunchTile on Launch {
+        __typename
+        id
+        isBooked
+        rocket {
+          id
+          name
+          __typename
+        }
+        mission {
+          name
+          missionPatch
+          __typename
+        }
+      }
+    `,
+    responseString: `
+      {
+        "data": {
+          "launches": {
+            "cursor": "1560349020",
+            "hasMore": true,
+            "launches": [
+              {
+                "__typename": "Launch",
+                "id": "99",
+                "isBooked": false,
+                "rocket": {
+                  "id": "falcon9",
+                  "name": "Falcon 9",
+                  "__typename": "Rocket"
+                },
+                "mission": {
+                  "name": "Starlink-9 (v1.0) & BlackSky Global 5-6",
+                  "missionPatch": "https://images2.imgbox.com/d2/3b/bQaWiil0_o.png",
+                  "__typename": "Mission"
+                }
+              },
+              {
+                "__typename": "Launch",
+                "id": "98",
+                "isBooked": true,
+                "rocket": {
+                  "id": "falcon9",
+                  "name": "Falcon 9",
+                  "__typename": "Rocket"
+                },
+                "mission": {
+                  "name": "ANASIS-II",
+                  "missionPatch": null,
+                  "__typename": "Mission"
+                }
+              },
+              {
+                "__typename": "Launch",
+                "id": "97",
+                "isBooked": false,
+                "rocket": {
+                  "id": "falcon9",
+                  "name": "Falcon 9",
+                  "__typename": "Rocket"
+                },
+                "mission": {
+                  "name": "GPS III SV03 (Columbus)",
+                  "missionPatch": null,
+                  "__typename": "Mission"
+                }
+              },
+              {
+                "__typename": "Launch",
+                "id": "96",
+                "isBooked": false,
+                "rocket": {
+                  "id": "falcon9",
+                  "name": "Falcon 9",
+                  "__typename": "Rocket"
+                },
+                "mission": {
+                  "name": "Starlink-8 & SkySat 16-18",
+                  "missionPatch": "https://images2.imgbox.com/d2/3b/bQaWiil0_o.png",
+                  "__typename": "Mission"
+                }
+              },
+              {
+                "__typename": "Launch",
+                "id": "95",
+                "isBooked": false,
+                "rocket": {
+                  "id": "falcon9",
+                  "name": "Falcon 9",
+                  "__typename": "Rocket"
+                },
+                "mission": {
+                  "name": "Starlink 7",
+                  "missionPatch": "https://images2.imgbox.com/d2/3b/bQaWiil0_o.png",
+                  "__typename": "Mission"
+                }
+              },
+              {
+                "__typename": "Launch",
+                "id": "94",
+                "isBooked": false,
+                "rocket": {
+                  "id": "falcon9",
+                  "name": "Falcon 9",
+                  "__typename": "Rocket"
+                },
+                "mission": {
+                  "name": "CCtCap Demo Mission 2",
+                  "missionPatch": "https://images2.imgbox.com/ab/79/Wyc9K7fv_o.png",
+                  "__typename": "Mission"
+                }
+              },
+              {
+                "__typename": "Launch",
+                "id": "93",
+                "isBooked": false,
+                "rocket": {
+                  "id": "falcon9",
+                  "name": "Falcon 9",
+                  "__typename": "Rocket"
+                },
+                "mission": {
+                  "name": "Starlink 6",
+                  "missionPatch": "https://images2.imgbox.com/d2/3b/bQaWiil0_o.png",
+                  "__typename": "Mission"
+                }
+              },
+              {
+                "__typename": "Launch",
+                "id": "92",
+                "isBooked": false,
+                "rocket": {
+                  "id": "falcon9",
+                  "name": "Falcon 9",
+                  "__typename": "Rocket"
+                },
+                "mission": {
+                  "name": "Starlink 5",
+                  "missionPatch": "https://images2.imgbox.com/d2/3b/bQaWiil0_o.png",
+                  "__typename": "Mission"
+                }
+              },
+              {
+                "__typename": "Launch",
+                "id": "91",
+                "isBooked": false,
+                "rocket": {
+                  "id": "falcon9",
+                  "name": "Falcon 9",
+                  "__typename": "Rocket"
+                },
+                "mission": {
+                  "name": "CRS-20",
+                  "missionPatch": "https://images2.imgbox.com/15/2b/NAcsTEB6_o.png",
+                  "__typename": "Mission"
+                }
+              },
+              {
+                "__typename": "Launch",
+                "id": "90",
+                "isBooked": false,
+                "rocket": {
+                  "id": "falcon9",
+                  "name": "Falcon 9",
+                  "__typename": "Rocket"
+                },
+                "mission": {
+                  "name": "Starlink 4",
+                  "missionPatch": "https://images2.imgbox.com/d2/3b/bQaWiil0_o.png",
+                  "__typename": "Mission"
+                }
+              },
+              {
+                "__typename": "Launch",
+                "id": "89",
+                "isBooked": false,
+                "rocket": {
+                  "id": "falcon9",
+                  "name": "Falcon 9",
+                  "__typename": "Rocket"
+                },
+                "mission": {
+                  "name": "Starlink 3",
+                  "missionPatch": "https://images2.imgbox.com/d2/3b/bQaWiil0_o.png",
+                  "__typename": "Mission"
+                }
+              },
+              {
+                "__typename": "Launch",
+                "id": "88",
+                "isBooked": false,
+                "rocket": {
+                  "id": "falcon9",
+                  "name": "Falcon 9",
+                  "__typename": "Rocket"
+                },
+                "mission": {
+                  "name": "Crew Dragon In Flight Abort Test",
+                  "missionPatch": "https://images2.imgbox.com/9d/04/DNXjbXDY_o.png",
+                  "__typename": "Mission"
+                }
+              },
+              {
+                "__typename": "Launch",
+                "id": "87",
+                "isBooked": false,
+                "rocket": {
+                  "id": "falcon9",
+                  "name": "Falcon 9",
+                  "__typename": "Rocket"
+                },
+                "mission": {
+                  "name": "Starlink 2",
+                  "missionPatch": "https://images2.imgbox.com/d2/3b/bQaWiil0_o.png",
+                  "__typename": "Mission"
+                }
+              },
+              {
+                "__typename": "Launch",
+                "id": "86",
+                "isBooked": false,
+                "rocket": {
+                  "id": "falcon9",
+                  "name": "Falcon 9",
+                  "__typename": "Rocket"
+                },
+                "mission": {
+                  "name": "JCSat 18 / Kacific 1",
+                  "missionPatch": "https://images2.imgbox.com/49/eb/evB1Wi95_o.png",
+                  "__typename": "Mission"
+                }
+              },
+              {
+                "__typename": "Launch",
+                "id": "85",
+                "isBooked": false,
+                "rocket": {
+                  "id": "falcon9",
+                  "name": "Falcon 9",
+                  "__typename": "Rocket"
+                },
+                "mission": {
+                  "name": "CRS-19",
+                  "missionPatch": "https://images2.imgbox.com/1f/40/3mc9OSdH_o.png",
+                  "__typename": "Mission"
+                }
+              },
+              {
+                "__typename": "Launch",
+                "id": "84",
+                "isBooked": false,
+                "rocket": {
+                  "id": "falcon9",
+                  "name": "Falcon 9",
+                  "__typename": "Rocket"
+                },
+                "mission": {
+                  "name": "Starlink 1",
+                  "missionPatch": "https://images2.imgbox.com/d2/3b/bQaWiil0_o.png",
+                  "__typename": "Mission"
+                }
+              },
+              {
+                "__typename": "Launch",
+                "id": "83",
+                "isBooked": false,
+                "rocket": {
+                  "id": "falcon9",
+                  "name": "Falcon 9",
+                  "__typename": "Rocket"
+                },
+                "mission": {
+                  "name": "Amos-17",
+                  "missionPatch": "https://images2.imgbox.com/a0/ab/XUoByiuR_o.png",
+                  "__typename": "Mission"
+                }
+              },
+              {
+                "__typename": "Launch",
+                "id": "82",
+                "isBooked": false,
+                "rocket": {
+                  "id": "falcon9",
+                  "name": "Falcon 9",
+                  "__typename": "Rocket"
+                },
+                "mission": {
+                  "name": "CRS-18",
+                  "missionPatch": "https://images2.imgbox.com/08/a2/bPpNeIRJ_o.png",
+                  "__typename": "Mission"
+                }
+              },
+              {
+                "__typename": "Launch",
+                "id": "81",
+                "isBooked": false,
+                "rocket": {
+                  "id": "falconheavy",
+                  "name": "Falcon Heavy",
+                  "__typename": "Rocket"
+                },
+                "mission": {
+                  "name": "STP-2",
+                  "missionPatch": "https://images2.imgbox.com/18/17/gCjLjHbl_o.png",
+                  "__typename": "Mission"
+                }
+              },
+              {
+                "__typename": "Launch",
+                "id": "80",
+                "isBooked": false,
+                "rocket": {
+                  "id": "falcon9",
+                  "name": "Falcon 9",
+                  "__typename": "Rocket"
+                },
+                "mission": {
+                  "name": "RADARSAT Constellation",
+                  "missionPatch": "https://images2.imgbox.com/c3/06/2irK3PGj_o.png",
+                  "__typename": "Mission"
+                }
+              }
+            ],
+            "__typename": "LaunchConnection"
+          }
+        },
+        "loading": false,
+        "networkStatus": 7,
+        "stale": false
+      }
+    `,
+    stateSnapshot: `TBD`,
+    diff: `TBD`,
+  },
+  {
+    queryString: `
+      query LaunchDetails($launchId: ID!) {
+        launch(id: $launchId) {
+          site
+          rocket {
+            type
+            __typename
+          }
+          ...LaunchTile
+          __typename
+        }
+      }
+      fragment LaunchTile on Launch {
+        __typename
+        id
+        isBooked
+        rocket {
+          id
+          name
+          __typename
+        }
+        mission {
+          name
+          missionPatch
+          __typename
+        }
+      }
+    `,
+    responseString: `
+      {
+        "data": {
+          "launch": {
+            "site": "KSC LC 39A",
+            "rocket": {
+              "type": "FT",
+              "__typename": "Rocket",
+              "id": "falcon9",
+              "name": "Falcon 9"
+            },
+            "__typename": "Launch",
+            "id": "99",
+            "isBooked": false,
+            "mission": {
+              "name": "Starlink-9 (v1.0) & BlackSky Global 5-6",
+              "missionPatch": "https://images2.imgbox.com/d2/3b/bQaWiil0_o.png",
+              "__typename": "Mission"
+            }
+          }
+        },
+        "loading": false,
+        "networkStatus": 7,
+        "stale": false
+      }
+    `,
+    stateSnapshot: `TBD`,
+    diff: `TBD`,
+  },
+];
+
+export const dummyQuery = {
+  queryString: `
+    query LaunchDetails($launchId: ID!) {
+      launch(id: $launchId) {
+        site
+        rocket {
+          type
+          __typename
+        }
+        ...LaunchTile
+        __typename
+      }
+    }
+    fragment LaunchTile on Launch {
+      __typename
+      id
+      isBooked
+      rocket {
+        id
+        name
+        __typename
+      }
+      mission {
+        name
+        missionPatch
+        __typename
+      }
+    }
+  `,
+  responseString: `
+    {
+      "data": {
+        "launch": {
+          "site": "KSC LC 39A",
+          "rocket": {
+            "type": "FT",
+            "__typename": "Rocket",
+            "id": "falcon9",
+            "name": "Falcon 9"
+          },
+          "__typename": "Launch",
+          "id": "99",
+          "isBooked": false,
+          "mission": {
+            "name": "Starlink-9 (v1.0) & BlackSky Global 5-6",
+            "missionPatch": "https://images2.imgbox.com/d2/3b/bQaWiil0_o.png",
+            "__typename": "Mission"
+          }
+        }
+      },
+      "loading": false,
+      "networkStatus": 7,
+      "stale": false
+    }
+  `,
+  stateSnapshot: `TBD`,
+  diff: `TBD`,
+};


### PR DESCRIPTION
Problem: Users have no way of navigating through the chrome extension to see the queries and the various information associated with the queries.

Solution: Users now have the ability to select queries from in side of the query list. Added in functionality to the navbar so that it properly switches to the correct info tab for the selected query.

Test: Fire up the extension and use the menu to navigate through it.