### PR TITLE
Initialize

### DIFF
--- a/chromeExtension/contentScript.js
+++ b/chromeExtension/contentScript.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-underscore-dangle */
 import sendMessageTypes from '../src/store/messagesAndActionTypes/messageTypes';
-import runInContext from '../src/util/contentScriptUtils';
+import injectAndRunInDom from '../src/util/contentScriptUtils';
 
 /*
 MESSAGE PARAMETERS
@@ -10,6 +10,7 @@ All Data Transfer Messages in Shape of : { type: senderType, payload: dataObj}
 All informational messages can be log messages sans data (data property on payload will print as undefined)
 */
 
+const timeout = 10; // ms to wait for Apollo to update
 const { epoch, contentScript, clientWindow } = sendMessageTypes;
 console.log('contentScript Running');
 
@@ -56,13 +57,13 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
     console.log(epoch.initialize);
 
     const { queryCount, mutationCount } = counts.getCounts();
-    runInContext(sendMessageWithCache, queryCount, mutationCount, true); // pass true for initialize param
+    injectAndRunInDom(sendMessageWithCache, queryCount, mutationCount, true); // pass true for initialize param
     sendResponse({ type: contentScript.initialCacheCheck }); // this response triggers exponential backoff check in Epoch Panel
   }
 
   if (message.type === epoch.fetchApolloData) {
     const { queryCount, mutationCount } = counts.getCounts();
-    runInContext(sendMessageWithCache, queryCount, mutationCount, false, true); // pass true for manual to flag response data
+    injectAndRunInDom(sendMessageWithCache, queryCount, mutationCount, false, true); // pass true for manual to flag response data
     sendResponse({ type: contentScript.log, payload: { title: 'Manual Fetch Triggered' } }); // should trigger response based on hasApollo in Redux
   }
 });
@@ -114,7 +115,11 @@ window.addEventListener('message', (event) => {
 window.addEventListener('keyup', (e) => {
   if (e.key === 'Enter') {
     const { queryCount, mutationCount } = counts.getCounts();
-    runInContext(sendMessageWithCache, queryCount, mutationCount);
+
+    // Get Cache AFTER Apollo updates
+    setTimeout(() => {
+      injectAndRunInDom(sendMessageWithCache, queryCount, mutationCount);
+    }, timeout);
 
     // Debug
     chrome.runtime.sendMessage({
@@ -132,7 +137,11 @@ window.addEventListener('keyup', (e) => {
 
 window.addEventListener('click', (e) => {
   const { queryCount, mutationCount } = counts.getCounts();
-  runInContext(sendMessageWithCache, queryCount, mutationCount);
+
+  // Get Cache AFTER Apollo updates
+  setTimeout(() => {
+    injectAndRunInDom(sendMessageWithCache, queryCount, mutationCount);
+  }, timeout);
 
   // Debug
   chrome.runtime.sendMessage({
@@ -170,6 +179,7 @@ const sendMessageWithCache = (queryCount, mutationCount, initialize, manualFetch
 
   // Get and format Data we need from window Obj
   const { queryIdCounter, mutationIdCounter, queries, mutationStore, link, cache } = apolloData;
+  const { store: mutations } = mutationStore;
 
   let graphQlUri;
   let cacheInstance;
@@ -251,7 +261,7 @@ const sendMessageWithCache = (queryCount, mutationCount, initialize, manualFetch
         manual: manualFetch,
         graphQlUri,
         queries: filterQueryInfo(queries), // array of Query objs
-        mutations: filterMutationInfo(mutationStore), // array of Mutation objs
+        mutations: filterMutationInfo(mutations), // array of Mutation objs
         cache: cacheInstance,
         queryCount: queryIdCounter,
         mutationCount: mutationIdCounter,
@@ -262,3 +272,5 @@ const sendMessageWithCache = (queryCount, mutationCount, initialize, manualFetch
     '*'
   );
 };
+
+injectAndRunInDom(sendMessageWithCache, 1, 1, true); // pass true for initialize param

--- a/chromeExtension/manifest.json
+++ b/chromeExtension/manifest.json
@@ -10,7 +10,7 @@
   },
   "background": {
     "scripts": ["background.js"],
-    "persistent": false
+    "persistent": true
   },
   "content_scripts": [
     {
@@ -18,5 +18,5 @@
       "js": ["contentScript.js"]
     }
   ],
-  "permissions": ["storage", "activeTab", "<all_urls>", "tabs"]
+  "permissions": ["storage", "activeTab", "<all_urls>", "tabs", "webRequest"]
 }

--- a/src/components/SphereLoader/SphereLoader.css
+++ b/src/components/SphereLoader/SphereLoader.css
@@ -1,0 +1,53 @@
+.loader__sphere--jump {
+  height: 80px;
+  width: 80px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.loader__sphere--jump span {
+  height: 15px;
+  width: 15px;
+  margin: 0 3px;
+  border-radius: 50%;
+  background-color: black;
+  animation: loader__sphere--jump 1.2s linear infinite;
+}
+
+.loader__sphere--jump span:nth-child(1) {
+  background-color: rgb(106, 230, 235);
+  animation-delay: -0.3s;
+}
+.loader__sphere--jump span:nth-child(2) {
+  background-color: rgb(221, 148, 240);
+  animation-delay: -0.2s;
+}
+.loader__sphere--jump span:nth-child(3) {
+  background-color: rgb(238, 62, 194);
+  animation-delay: -0.1s;
+}
+
+@keyframes loader__sphere--jump {
+  25% {
+    height: 12px;
+    border-bottom-left-radius: 25%;
+    border-bottom-right-radius: 25%;
+    transform: translateY(0);
+  }
+
+  50% {
+    height: 15px;
+    border-bottom-left-radius: 50%;
+    border-bottom-right-radius: 50%;
+    transform: translateY(-50%);
+  }
+
+  75% {
+    border-top-left-radius: 50%;
+    border-top-right-radius: 50%;
+    border-bottom-left-radius: 50%;
+    border-bottom-right-radius: 50%;
+    transform: translateY(0);
+  }
+}

--- a/src/components/SphereLoader/SphereLoader.jsx
+++ b/src/components/SphereLoader/SphereLoader.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import './SphereLoader.css';
+
+const SphereLoader = () => (
+  <div className="loader__sphere--jump">
+    <span />
+    <span />
+    <span />
+  </div>
+);
+
+export default SphereLoader;

--- a/src/containers/App.jsx
+++ b/src/containers/App.jsx
@@ -3,18 +3,19 @@ import * as React from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import HistoryContainer from './HistoryContainer';
 import InfoContainer from './InfoContainer';
+import SphereLoader from '../components/SphereLoader/SphereLoader';
 import { initializeBackgroundConnection, fetchApollo } from '../store/entities/apollo';
 import '../styles/main.css';
 
 const App = () => {
-  // eslint-disable-next-line no-shadow
-  const state = useSelector((state) => state);
-  console.log('state', state);
   const dispatch = useDispatch();
+  const loadingApollo = useSelector((state) => state.apollo.loadingApollo);
 
   React.useEffect(() => {
-    console.log('Use Effect Fired');
-    console.log('TabID in Effect', chrome.devtools.inspectedWindow.tabId);
+    console.log(
+      'Initializing Background Connection on Tab: ',
+      chrome.devtools.inspectedWindow.tabId
+    );
     dispatch(initializeBackgroundConnection());
   }, []);
 
@@ -26,7 +27,12 @@ const App = () => {
     <div className="wrapper">
       <div className="main">
         <div className="heading">
-          <h1>Hola Monde!!!</h1>
+          {loadingApollo && (
+            <div className="loader">
+              <h2>Detecting Apollo</h2>
+              <SphereLoader />
+            </div>
+          )}
         </div>
         <div className="containers-wrapper">
           {/* // render out history  */}

--- a/src/store/entities/apollo.js
+++ b/src/store/entities/apollo.js
@@ -2,7 +2,6 @@
 import { createAction, createReducer } from '@reduxjs/toolkit';
 import { createSelector } from 'reselect';
 import { print } from 'graphql/language/printer';
-import { array } from 'prop-types';
 import { connectToBackground } from '../messagesAndActionTypes/initializeActions';
 import sendMessageTypes from '../messagesAndActionTypes/messageTypes';
 
@@ -76,6 +75,7 @@ const manualFetchType = 'Manual Fetch';
 
 const initialState = {
   hasDunderApollo: false,
+  loadingApollo: false,
   activeQuery: {},
   prevQuery: {},
   chromeTabId: '',
@@ -147,7 +147,13 @@ function startingUpCase(state, action) {
 }
 
 function initializePortCase(state, action) {
+  console.log('Port Initialized');
+  state.loadingApollo = true;
   superPort = action.payload;
+  superPort.connection.postMessage({
+    type: sendMessageTypes.epoch.initialize,
+    payload: chrome.devtools.inspectedWindow.tabId,
+  });
 }
 
 function callBackgroundCase(state, action) {
@@ -165,6 +171,7 @@ function fetchApolloCase(state, action) {
 function noApolloCase(state, action) {
   console.log('No Apollo Case');
   state.hasDunderApollo = false;
+  state.loadingApollo = false;
 }
 
 function receivedApolloCase(state, action) {
@@ -293,6 +300,7 @@ function processApolloData(state, apolloData) {
     } = apolloObj;
 
     state.hasDunderApollo = true;
+    state.loadingApollo = false;
     state.graphQlUri = graphQlUri;
     console.log(`CurrQ: ${queryCount}, PrevQ: ${prevQueryCount}, StateQ: ${state.queryIdCounter}`);
     console.log(

--- a/src/store/entities/apollo.js
+++ b/src/store/entities/apollo.js
@@ -2,6 +2,7 @@
 import { createAction, createReducer } from '@reduxjs/toolkit';
 import { createSelector } from 'reselect';
 import { print } from 'graphql/language/printer';
+import { array } from 'prop-types';
 import { connectToBackground } from '../messagesAndActionTypes/initializeActions';
 import sendMessageTypes from '../messagesAndActionTypes/messageTypes';
 
@@ -168,77 +169,7 @@ function noApolloCase(state, action) {
 
 function receivedApolloCase(state, action) {
   const apolloData = action.payload;
-  const {
-    graphQlUri,
-    queries,
-    mutations,
-    cache,
-    queryCount,
-    mutationCount,
-    prevQueryCount,
-    prevMutationCount,
-  } = apolloData;
-
-  state.hasDunderApollo = true;
-  state.graphQlUri = graphQlUri;
-  console.log(`CurrQ: ${queryCount}, PrevQ: ${prevQueryCount}, StateQ: ${state.queryIdCounter}`);
-  console.log(
-    `CurrM: ${mutationCount}, PrevM: ${prevMutationCount}, StateM: ${state.mutationIdCounter}`
-  );
-
-  // Debug
-  if (state.queryIdCounter !== prevQueryCount || state.mutationIdCounter !== prevMutationCount) {
-    console.log('*****QUERIES / MUTATIONS MISSED*****');
-    console.log(`CurrQ: ${queryCount}, PrevQ: ${prevQueryCount}, StateQ: ${state.queryIdCounter}`);
-    console.log(
-      `CurrM: ${mutationCount}, PrevM: ${prevMutationCount}, StateM: ${state.mutationIdCounter}`
-    );
-  }
-
-  let mutationsToGrab = mutationCount - prevMutationCount;
-  if (mutationsToGrab && mutationsToGrab <= mutations.length) {
-    while (mutationsToGrab > 0) {
-      const { id, document, error, variables } = mutations.pop();
-      const stateMutationObj = {
-        id,
-        type: mutationType,
-        queryString: print(document),
-        variables,
-        cacheSnapshot: cache,
-        diff: 'Magic Diff Formula Magic Result Inserted Here',
-      };
-      state.timeline.push(id);
-      state.mutationIds.push(id);
-      state.mutations[id] = stateMutationObj;
-      mutationsToGrab -= 1;
-    }
-  }
-  state.mutationIdCounter = mutationCount;
-
-  let queriesToGrab = queryCount - prevQueryCount;
-  if (queriesToGrab && queriesToGrab <= queries.length) {
-    while (queriesToGrab > 0) {
-      console.log('received Q Case queries ->', queries);
-      console.log('query items ->', queries.length);
-      const queryObj = queries.pop();
-      console.log('q in question -> ', queryObj);
-      const { id, document, lastResult, variables } = queryObj;
-      const stateQueryObj = {
-        id,
-        type: queryType,
-        queryString: print(document),
-        variables,
-        response: lastResult,
-        cacheSnapshot: cache,
-        diff: 'Magic Diff Formula Magic Result Inserted Here',
-      };
-      state.timeline.push(id);
-      state.queryIds.push(id);
-      state.queries[id] = stateQueryObj;
-      queriesToGrab -= 1;
-    }
-  }
-  state.queryIdCounter = queryCount;
+  state = processApolloData(state, apolloData);
 }
 
 function receivedManualFetchCase(state, action) {
@@ -345,6 +276,90 @@ export const getTimeline = createSelector(
 /*--------------
 HELPERS
 ---------------*/
-function createQueryString(document) {
-  return print(document);
+function processApolloData(state, apolloData) {
+  // We can receive this data in two ways, an array of apollo objects (epoch initialized after client app already running)
+  // Or a single object (normal course of busn, or epoch already initialized when client app loaded)
+
+  function processCacheObj(apolloObj) {
+    const {
+      graphQlUri,
+      queries,
+      mutations,
+      cache,
+      queryCount,
+      mutationCount,
+      prevQueryCount,
+      prevMutationCount,
+    } = apolloObj;
+
+    state.hasDunderApollo = true;
+    state.graphQlUri = graphQlUri;
+    console.log(`CurrQ: ${queryCount}, PrevQ: ${prevQueryCount}, StateQ: ${state.queryIdCounter}`);
+    console.log(
+      `CurrM: ${mutationCount}, PrevM: ${prevMutationCount}, StateM: ${state.mutationIdCounter}`
+    );
+
+    // Debug
+    if (state.queryIdCounter !== prevQueryCount || state.mutationIdCounter !== prevMutationCount) {
+      console.log('*****QUERIES / MUTATIONS MISSED*****');
+      console.log(
+        `CurrQ: ${queryCount}, PrevQ: ${prevQueryCount}, StateQ: ${state.queryIdCounter}`
+      );
+      console.log(
+        `CurrM: ${mutationCount}, PrevM: ${prevMutationCount}, StateM: ${state.mutationIdCounter}`
+      );
+    }
+
+    let mutationsToGrab = mutationCount - prevMutationCount;
+    if (mutationsToGrab && mutationsToGrab <= mutations.length) {
+      while (mutationsToGrab > 0) {
+        const { id, document, error, variables } = mutations.pop();
+        console.log('mutationDocument', document);
+        const stateMutationObj = {
+          id,
+          type: mutationType,
+          queryString: print(document),
+          variables,
+          cacheSnapshot: cache,
+          diff: 'Magic Diff Formula Magic Result Inserted Here',
+        };
+        state.timeline.push(id);
+        state.mutationIds.push(id);
+        state.mutations[id] = stateMutationObj;
+        mutationsToGrab -= 1;
+      }
+    }
+    state.mutationIdCounter = mutationCount;
+
+    let queriesToGrab = queryCount - prevQueryCount;
+    if (queriesToGrab && queriesToGrab <= queries.length) {
+      while (queriesToGrab > 0) {
+        console.log('received Q Case queries ->', queries);
+        console.log('query items ->', queries.length);
+        const queryObj = queries.pop();
+        console.log('q in question -> ', queryObj);
+        const { id, document, lastResult, variables } = queryObj;
+        const stateQueryObj = {
+          id,
+          type: queryType,
+          queryString: print(document),
+          variables,
+          response: lastResult,
+          cacheSnapshot: cache,
+          diff: 'Magic Diff Formula Magic Result Inserted Here',
+        };
+        state.timeline.push(id);
+        state.queryIds.push(id);
+        state.queries[id] = stateQueryObj;
+        queriesToGrab -= 1;
+      }
+    }
+    state.queryIdCounter = queryCount;
+  }
+  if (Array.isArray(apolloData)) {
+    apolloData.forEach((apolloObj) => processCacheObj(apolloObj));
+  } else {
+    processCacheObj(apolloData);
+  }
+  return state;
 }

--- a/src/store/middleware/createBackgroundPort.js
+++ b/src/store/middleware/createBackgroundPort.js
@@ -33,14 +33,6 @@ const initializePort = ({ dispatch }) => (next) => (action) => {
     const backgroundConnection = chrome.runtime.connect();
 
     backgroundConnection.onMessage.addListener((message, sender, sendResponse) => {
-      /*
-      Backgroung.noApolloClient
-      background.apolloReceivedManual
-      background.apolloReceived
-      background.log
-      contentScript.initializeCacheCheck
-      conntentScript.log
-      */
       if (message.type === contentScript.initialCacheCheck) {
         dispatch({ type: initializeCache });
       }

--- a/src/util/contentScriptUtils.js
+++ b/src/util/contentScriptUtils.js
@@ -13,7 +13,7 @@ import { print } from 'graphql/language/printer';
 
 export const newPrint = print;
 
-const runInPageContext = (method, ...args) => {
+const injectAndRunInDom = (method, ...args) => {
   // The stringified method which will be parsed as a function object.
   const stringifiedMethod = method instanceof Function ? method.toString() : `() => { ${method} }`;
 
@@ -36,4 +36,4 @@ const runInPageContext = (method, ...args) => {
   document.documentElement.prepend(scriptElement);
 };
 
-export default runInPageContext;
+export default injectAndRunInDom;


### PR DESCRIPTION
**Problem**
In order to adequately listen to web requests we have to identify the graphQL URL to listen for. There was no code to fetch a cache with the Epoch panel initialized and so we never had the URL to pass to our webRequest listener as a filter. 

**Solution**
Code to initialize Epoch. There were several cases to cover - Content and Background scripts initialize, but no Epoch panel is open. Epoch panel open as site is refreshed. 
Now, when content and background scripts are running before an Epoch panel is open, the Background scripts store query information until an Epoch panel opens. ---WE MAY WANT TO REFACTOR THIS TO USE CHROME STORAGE---. When an Epoch panel is opened that history is passed to Epoch along with a current cache fetch. Epoch can now handle an array of apolloObjects or a single apolloObject to account for this initialization.

To facilitate the initial search for a dunder Apollo, loading flags were added to state and a loader was added to the components folder for testing. We can and should remove / adjust this loader component to mesh with our design. It currently does not.

**To Test**
-Fire up the extension and the test website. Click around on a few things you know will generate queries. Open an epoch panel. You query history should load automatically. 
-Reload the epoch frame. That history should no longer be captured, but future queries and mutations should still populate. 
-Reload the page. Epoch should continue tracking new queries. 
-Navigate to a page without a dunder Apollo. A loader should display endlessly (yes we need to clean this up).
-Open your Epoch Console AND you background console. They should both be logging web requests (ultimately we can remove the console log for webRequests from the background page).