### PR TITLE
Bug fix to clear app data on page refresh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,3 +108,5 @@ dist
 
 .vsCode
 
+.DS_Store
+

--- a/chromeExtension/background.js
+++ b/chromeExtension/background.js
@@ -65,6 +65,13 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
         payload: { title: `Background connected to content and Epoch Panel Instance ${portId}` },
       });
     }
+
+    if (connections[portId]) {
+      connections[portId].postMessage({
+        type: contentScript.clearData,
+      });
+    }
+
     sendResponse({ type: 'Background Connected to Content' });
   }
 

--- a/src/components/QueryInfo.jsx
+++ b/src/components/QueryInfo.jsx
@@ -1,19 +1,45 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import { GraphqlCodeBlock } from 'graphql-syntax-highlighter-react';
+import ReactJson from 'react-json-view';
+import { epochTheme } from '../styles/themes/EpochTheme';
 import '../styles/graphQLCodeBlock.css';
 
 // export interface QueryInfoProps {}
 
-const QueryInfo = ({ queryString }) => {
+const QueryInfo = ({ queryString, variables }) => {
   return (
     <div>
       {!queryString && <h2>No Query String to Render</h2>}
-      {queryString && <GraphqlCodeBlock className="GraphqlCodeBlock" queryBody={queryString} />}
+      {queryString && (
+        <>
+          <p>Query String</p>
+          <GraphqlCodeBlock className="GraphqlCodeBlock" queryBody={queryString} />
+        </>
+      )}
+      {queryString && (
+        <>
+          <br />
+          <p>Variables</p>
+          <br />
+          <ReactJson
+            src={variables}
+            enableClipboard={false}
+            theme={epochTheme}
+            name={false}
+            displayObjectSize={false}
+            displayDataTypes={false}
+            indentWidth={2}
+          />
+        </>
+      )}
     </div>
   );
 };
 
-QueryInfo.propTypes = { queryString: PropTypes.string.isRequired };
+QueryInfo.propTypes = {
+  queryString: PropTypes.string.isRequired,
+  variables: PropTypes.object.isRequired,
+};
 
 export default QueryInfo;

--- a/src/containers/InfoContainer.jsx
+++ b/src/containers/InfoContainer.jsx
@@ -19,7 +19,9 @@ const InfoContainer = () => {
   // get selected query based on state
   const selectedQuery = useSelector((state) => state.apollo.activeQuery);
   const info = {
-    QueryInfo: <QueryInfo queryString={selectedQuery.queryString} />,
+    QueryInfo: (
+      <QueryInfo queryString={selectedQuery.queryString} variables={selectedQuery.variables} />
+    ),
     ResponseInfo: <ResponseInfo response={selectedQuery.response} />,
     StateInfo: <StateInfo stateSnapshot={selectedQuery.cacheSnapshot} />,
     DiffInfo: <DiffInfo diff={selectedQuery.diff} />,

--- a/src/store/entities/apollo.js
+++ b/src/store/entities/apollo.js
@@ -107,6 +107,7 @@ const RECEIVED_APOLLO = 'apolloReceived';
 const INITIALIZED_CACHE_CHECK = 'initializedCache';
 const SET_ACTIVE_QUERY = 'setActiveQuery';
 const SET_PREV_QUERY = 'setPrevQuery';
+const CLEAR_APOLLO_DATA = 'clearApolloData';
 
 /*----------------
   ACTION CREATORS
@@ -122,6 +123,7 @@ export const receivedApollo = createAction(RECEIVED_APOLLO); // payload apolloOb
 export const initializeCache = createAction(INITIALIZED_CACHE_CHECK);
 export const setActiveQuery = createAction(SET_ACTIVE_QUERY); // payload should be an ID from the timeline
 export const setPrevQuery = createAction(SET_PREV_QUERY); // payload should be an ID from the timeline
+export const clearApolloData = createAction(CLEAR_APOLLO_DATA);
 
 /*--------------
   REDUCER
@@ -137,6 +139,7 @@ const apolloReducer = createReducer(initialState, {
   [INITIALIZED_CACHE_CHECK]: initializedCacheCase,
   [SET_ACTIVE_QUERY]: setActiveQueryCase,
   [SET_PREV_QUERY]: setPrevQueryCase,
+  [CLEAR_APOLLO_DATA]: clearApolloDataCase,
 });
 
 /*--------------
@@ -239,6 +242,27 @@ function setPrevQueryCase(state, action) {
   if (typeIndicator === 'F') state.activeQuery = state.manualFetches[prevQueryId];
 }
 
+function clearApolloDataCase(state, action) {
+  console.log('Re-initializing state');
+  state.hasDunderApollo = false;
+  state.loadingApollo = false;
+  state.activeQuery = {};
+  state.prevQuery = {};
+  state.chromeTabId = '';
+  state.graphQlUri = '';
+  state.queryIds = [];
+  state.queries = {};
+  state.queryIdCounter = 1;
+  state.mutationIds = [];
+  state.mutations = {};
+  state.mutationIdCounter = 1;
+  state.manualFetches = {}; // store manual cacheFetches in Timeline
+  state.manualFetchIds = [];
+  state.fetchCounter = 0;
+  state.timeline = []; // an ordered list of query and mutation Ids
+  state.typeNameDocumentCache = {};
+}
+
 export default apolloReducer;
 
 /*--------------------
@@ -252,6 +276,7 @@ export const initializeBackgroundConnection = () =>
     onStart: STARTING_UP,
     onSuccess: PORT_INITIALIZED,
     apolloActions: {
+      clearApolloData: CLEAR_APOLLO_DATA,
       receivedApollo: RECEIVED_APOLLO,
       receivedApolloManual: RECEIVED_MANUAL_FETCH,
       noApollo: NO_APOLLO,

--- a/src/store/messagesAndActionTypes/messageTypes.js
+++ b/src/store/messagesAndActionTypes/messageTypes.js
@@ -12,6 +12,7 @@ const sendMessageTypes = {
     apolloReceivedManual: 'apolloDataReceivedManual',
     noApolloClient: 'noApollo',
     initialCacheCheck: 'checkingForCache',
+    clearData: 'clearApolloData',
     log: LOG,
     error: ERROR,
   },

--- a/src/store/middleware/createBackgroundPort.js
+++ b/src/store/middleware/createBackgroundPort.js
@@ -29,7 +29,13 @@ const initializePort = ({ dispatch }) => (next) => (action) => {
     const { tabId } = chrome.devtools.inspectedWindow;
     const dispatch = dispatchFunction;
     const { apolloActions } = action.payload;
-    const { receivedApollo, receivedApolloManual, noApollo, initializeCache } = apolloActions;
+    const {
+      receivedApollo,
+      receivedApolloManual,
+      noApollo,
+      initializeCache,
+      clearApolloData,
+    } = apolloActions;
     const backgroundConnection = chrome.runtime.connect();
 
     backgroundConnection.onMessage.addListener((message, sender, sendResponse) => {
@@ -39,6 +45,10 @@ const initializePort = ({ dispatch }) => (next) => (action) => {
 
       if (message.type === background.log || message.type === contentScript.log) {
         dispatch(log(message.payload));
+      }
+
+      if (message.type === contentScript.clearData) {
+        dispatch({ type: clearApolloData });
       }
 
       if (message.type === background.noApolloClient) {


### PR DESCRIPTION
Problem: 1) App data persists across page refreshes. 2) Variables for queries and mutations were being stored but not shown to the user.

Solution: 1) Added an action to the redux to clear all app data. This action is fired every time the content script is loaded which should happen on a page refresh. 2) Added code to the components to make variables visible.

Test: Open the app, perform some queries, refresh the page. Query list should empty automatically. Variables should also be viewable in queries and mutations.