### PR TITLE
Fixed No Cache without active crash

### DIFF
--- a/src/components/StateInfo.jsx
+++ b/src/components/StateInfo.jsx
@@ -9,8 +9,13 @@ const StateInfo = ({ stateSnapshot }) => {
   const [activeKey, setActiveKey] = React.useState(null);
   return (
     <div className="cache-display">
-      <StateSidebar keyList={Object.keys(stateSnapshot)} onClick={setActiveKey} />
-      {activeKey !== null && <StateValueDisplay stateValue={stateSnapshot[activeKey]} />}
+      {!stateSnapshot && <h2>No Cache</h2>}
+      {stateSnapshot && (
+        <>
+          <StateSidebar keyList={Object.keys(stateSnapshot)} onClick={setActiveKey} />
+          {activeKey !== null && <StateValueDisplay stateValue={stateSnapshot[activeKey]} />}
+        </>
+      )}
     </div>
   );
 };

--- a/src/containers/InfoContainer.jsx
+++ b/src/containers/InfoContainer.jsx
@@ -5,7 +5,6 @@ import QueryInfo from '../components/QueryInfo';
 import ResponseInfo from '../components/ResponseInfo';
 import StateInfo from '../components/StateInfo';
 import DiffInfo from '../components/DiffInfo';
-import { dummyQuery } from '../dummyData/data';
 
 // export interface InfoContainerProps {}
 

--- a/src/store/entities/apollo.js
+++ b/src/store/entities/apollo.js
@@ -270,6 +270,7 @@ function receivedNetworkQueryCase(state, action) {
   state.timeline.push(id);
   delete state.networkHoldingRoom[queryKey];
   console.log('networkHoldingRoom Clean', state.networkHoldingRoom);
+}
 
 function clearApolloDataCase(state, action) {
   console.log('Re-initializing state');


### PR DESCRIPTION
**Problem**
On initialization, when no active query was selected, clicking on the cache tab caused a crash

**Solution**
Conditionally render cache data based on whether or not cache is available

**Test**
Fire up the app. Don't select an query / mutation. Click the cache tab